### PR TITLE
[Do not merge] Attempt to import ethers.Wallet in deno

### DIFF
--- a/src/app/deps.ts
+++ b/src/app/deps.ts
@@ -11,16 +11,19 @@ export type {
 } from "https://deno.land/x/oak/mod.ts";
 
 // Database dependencies
-export { Client } from "https://deno.land/x/postgres/mod.ts"
-export {
-    QueryClient,
-    DataType,
-    Constraint,
-    CreateTableMode,
-} from "https://deno.land/x/postquery/mod.ts"
+// export { Client } from "https://deno.land/x/postgres/mod.ts"
+// export {
+//     QueryClient,
+//     DataType,
+//     Constraint,
+//     CreateTableMode,
+// } from "https://deno.land/x/postquery/mod.ts"
 
-export type {
-    TableOptions
-} from "https://deno.land/x/postquery/mod.ts"
+// export type {
+//     TableOptions
+// } from "https://deno.land/x/postquery/mod.ts"
 
+import type { Wallet as WalletType } from "https://cdn.skypack.dev/-/@ethersproject/wallet@v5.1.0-mpoCY8R8syeSEFVDZmv5/dist=es2020,mode=types/lib/index.d.ts";
 
+import ethers from "https://dev.jspm.io/ethers@5.1.0";
+export const Wallet = (ethers as any).Wallet as { new(): WalletType };

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,3 @@
+import { Wallet } from "./src/app/deps.ts";
+
+console.log(Wallet);


### PR DESCRIPTION
Hey James. I spent some time with this this evening. From what I can tell, using deno with this code that's intended for node is pretty nontrivial. It's not just about getting the syntax right, there's real compatibility problems. Getting ethers running on deno would be pretty cool though, do you know whether there's much interest in that?

Anyway, I had some limited results here. I used a Frankenstein where it gets the actual js implementation via jspm and then uses the type definitions from skypack. This code loads correctly and has correct type information, however although `console.log(Wallet);` works fine, when you do `new Wallet()` you get this:

```
error: Uncaught TypeError: Cannot read property 'toHexString' of undefined
    return !!value.toHexString;
                   ^
    at isHexable (https://dev.jspm.io/npm:@ethersproject/bytes@5.1.0/lib/index.dew.js:20:20)
    at Object.hexlify (https://dev.jspm.io/npm:@ethersproject/bytes@5.1.0/lib/index.dew.js:231:9)
    at new SigningKey (https://dev.jspm.io/npm:@ethersproject/signing-key@5.1.0/lib/index.dew.js:42:63)
    at new Wallet (https://dev.jspm.io/npm:@ethersproject/wallet@5.1.0/lib/index.dew.js:293:30)
    at file:///Users/andrew/workspaces/eth-foundation/aggregator/test.ts:5:13
```

According to this open issue, jspm does not have any support yet for type defintions for deno:
https://github.com/jspm/project/issues/55

skypack has implemented type definitions via a `x-typescript-types` header. However I didn't get as far using skypack alone because there's an issue in `@ethersproject/signing-key` where it relies on `hash.js` from npm but doesn't declare it in its `package.json`.

You can see the issue in skypack here:
https://cdn.skypack.dev/-/@ethersproject/signing-key@v5.1.0-QKyFcptZith2NXJwBfGJ/dist=es2020,mode=imports/optimized/@ethersproject/signing-key.js

On this line:
```js
import "/error/unknown:hash.js?from=@ethersproject/signing-key";
```

Which is a special module containing:
```js
throw new Error("[Package Error] \"hash.js\" no dependency version info found. ");
```

We could probably resolve the hash.js thing by collaborating with the ethers contributors, but that's unlikely to be the only issue blocking us here.