### PR TITLE
Issue #9: Enable upgrading to latest deno (currently 1.11.2) by adding TLS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Gateway.
 
 ## Installation
 
-Install [Deno](deno.land) (or `deno upgrade`) v1.9.1.
-Uses ethers, Oak, Postgresql... see src/app/deps.ts
+Install [Deno](deno.land). Uses ethers, Oak, Postgresql... see src/app/deps.ts.
 
 ```sh
 cp .env.example .env
@@ -49,6 +48,25 @@ Create a table called `bls_aggregator`:
 ```sh
 sudo -u postgres createdb bls_aggregator
 ```
+
+On Ubuntu (and probably elsewhere), postgres is configured to offer SSL
+connections but with an invalid certificate. However, the deno driver for
+postgres doesn't support this.
+
+There are two options here:
+
+1. Set up SSL with a valid certificate
+   ([guide](https://www.postgresql.org/docs/current/ssl-tcp.html)).
+2. Turn off SSL in postgres (only for development or if you can ensure the
+   connection isn't vulnerable to attack).
+   1. View the config location with
+      `sudo -u postgres psql -c 'SHOW config_file'`.
+   2. Turn off ssl in that config.
+      ```diff
+      -ssl = on
+      +ssl = off
+      ```
+   3. Restart postgres `sudo systemctl restart postgresql`.
 
 ## Running
 

--- a/deps/index.ts
+++ b/deps/index.ts
@@ -36,9 +36,9 @@ export {
   DataType,
   QueryClient,
   QueryTable,
-} from "https://deno.land/x/postquery@v0.0.4/mod.ts";
+} from "https://deno.land/x/postquery@v0.1.0/mod.ts";
 
-export type { TableOptions } from "https://deno.land/x/postquery@v0.0.4/mod.ts";
+export type { TableOptions } from "https://deno.land/x/postquery@v0.1.0/mod.ts";
 
 import * as hubbleBlsImport from "./hubble-bls/mod.ts";
 await hubbleBlsImport.mcl.init();

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -12,7 +12,7 @@ import TxTable from "./TxTable.ts";
 
 const walletService = new WalletService(env.PRIVATE_KEY_AGG);
 const txTable = await TxTable.create(env.TX_TABLE_NAME);
-const txService = new TxService(txTable);
+const txService = new TxService(txTable, walletService);
 const adminService = new AdminService(walletService, txTable);
 
 const routers = [


### PR DESCRIPTION
https://github.com/jzaki/aggregator/issues/9

We got the updated postgres driver, but it turns out connecting to a server offering ssl with an invalid certificate (which is what you get out of the box on e.g. Ubuntu) is just-not-supported by the postgres driver.

This is why the terminology for the flag is whether tls is 'enforced' rather than 'enabled'. Also evidenced by this code:

```ts
    if (sslmode !== "require" && sslmode !== "prefer") {
      throw new ConnectionParamsError(
        `Supplied DSN has invalid sslmode '${sslmode}'. Only 'require' or 'prefer' are supported`,
      );
    }
```
https://deno.land/x/postgres@v0.11.2/connection/connection_params.ts#L126-L130

i.e., the lowest level of tls protection is 'prefer', meaning that it must use the tls connection if it is available.

For our use case, which is to access postgres over a local connection only, it's my understanding that pushing tls in this way is not warranted. I'm not aware of any reasonable attack vectors on a local connection that wouldn't compromise security anyway (when would you be able to intercept localhost but not e.g. edit the source code?).

For now I've worded the non-TLS advice as "only for development or if you can ensure the connection isn't vulnerable to attack". However, given the attitude of the driver authors and postgres authors to TLS, I've also added https://github.com/jzaki/aggregator/issues/26 to follow-up here.