### PR TITLE
Issue #33: Address concurrency issues

### DIFF
--- a/src/app/TxService.ts
+++ b/src/app/TxService.ts
@@ -49,9 +49,9 @@ export default class TxService {
 
       if (highestReadyNonce === txData.nonce) {
         this.readyTxTable.add(txData);
-        this.tryMoveFutureTxs(txData.pubKey, highestReadyNonce + 1);
+        await this.tryMoveFutureTxs(txData.pubKey, highestReadyNonce + 1);
       } else {
-        this.ensureFutureTxSpace();
+        await this.ensureFutureTxSpace();
         this.futureTxTable.add(txData);
       }
 
@@ -106,7 +106,7 @@ export default class TxService {
 
       for (const tx of bestFutureTxs) {
         if (tx.nonce < highestReadyNonce) {
-          this.replaceReadyTx(highestReadyNonce, tx);
+          await this.replaceReadyTx(highestReadyNonce, tx);
         } else if (tx.nonce === highestReadyNonce) {
           const txWithoutId = { ...tx };
           delete txWithoutId.txId;

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -10,8 +10,12 @@ import errorHandler from "./errorHandler.ts";
 import notFoundHandler from "./notFoundHandler.ts";
 import TxTable from "./TxTable.ts";
 import createQueryClient from "./createQueryClient.ts";
+import Mutex from "../helpers/Mutex.ts";
 
 const queryClient = createQueryClient();
+
+const txTablesMutex = new Mutex();
+
 const readyTxTable = await TxTable.create(queryClient, env.TX_TABLE_NAME);
 
 const futureTxTable = await TxTable.create(
@@ -20,7 +24,14 @@ const futureTxTable = await TxTable.create(
 );
 
 const walletService = new WalletService(env.PRIVATE_KEY_AGG);
-const txService = new TxService(futureTxTable, readyTxTable, walletService);
+
+const txService = new TxService(
+  queryClient,
+  txTablesMutex,
+  futureTxTable,
+  readyTxTable,
+  walletService,
+);
 
 const adminService = new AdminService(
   walletService,

--- a/src/app/runQueryGroup.ts
+++ b/src/app/runQueryGroup.ts
@@ -1,0 +1,21 @@
+import { QueryClient } from "../../deps/index.ts";
+import Mutex from "../helpers/Mutex.ts";
+
+export default async function runQueryGroup<T>(
+  mutex: Mutex,
+  queryClient: QueryClient,
+  body: () => Promise<T>,
+) {
+  const lock = await mutex.Lock();
+  let completed = false;
+
+  try {
+    queryClient.query("BEGIN");
+    const result = await body();
+    completed = true;
+    return result;
+  } finally {
+    lock.release();
+    await queryClient.query(completed ? "COMMIT" : "ROLLBACK");
+  }
+}

--- a/src/helpers/Mutex.ts
+++ b/src/helpers/Mutex.ts
@@ -1,0 +1,53 @@
+class Lock {
+  release: () => void;
+
+  constructor(release: (lock: Lock) => void) {
+    this.release = () => release(this);
+  }
+}
+
+export default class Mutex {
+  #queue: ((lock: Lock) => void)[] = [];
+  #currentLock: Lock | null = null;
+
+  tryLock(): Lock | null {
+    if (this.#currentLock === null) {
+      this.#currentLock = new Lock((lock) => this.#release(lock));
+      return this.#currentLock;
+    }
+
+    return null;
+  }
+
+  Lock(): Promise<Lock> {
+    const lock = this.tryLock();
+
+    if (lock) {
+      return Promise.resolve(lock);
+    }
+
+    return new Promise<Lock>((resolve) => this.#queue.push(resolve));
+  }
+
+  isLocked() {
+    return this.#currentLock !== null;
+  }
+
+  #release(lock: Lock) {
+    if (lock !== this.#currentLock) {
+      throw new Error("invalid release");
+    }
+
+    this.#currentLock = null;
+
+    const resolveNext = this.#queue.shift();
+
+    if (resolveNext) {
+      resolveNext(this.tryLock()!);
+    }
+  }
+
+  isCurrentLock(lock: Lock) {
+    return lock === this.#currentLock;
+  }
+}

--- a/test/TxTable.test.ts
+++ b/test/TxTable.test.ts
@@ -18,8 +18,12 @@ function test(name: string, fn: (txTable: TxTable) => Promise<void>) {
       try {
         await fn(txTable);
       } finally {
-        await txTable.drop();
-        await queryClient.disconnect();
+        try {
+          await txTable.drop();
+          await queryClient.disconnect();
+        } catch (error) {
+          console.error("cleanup error:", error);
+        }
       }
     },
   });

--- a/test/helpers/Fixture.ts
+++ b/test/helpers/Fixture.ts
@@ -9,6 +9,7 @@ import dataPayload from "./dataPayload.ts";
 import TxService from "../../src/app/TxService.ts";
 import createQueryClient from "../../src/app/createQueryClient.ts";
 import Range from "./Range.ts";
+import Mutex from "../../src/helpers/Mutex.ts";
 
 const DOMAIN_HEX = ethers.utils.keccak256("0xfeedbee5");
 const DOMAIN = ethers.utils.arrayify(DOMAIN_HEX);
@@ -165,6 +166,8 @@ export default class Fixture {
     const suffix = this.rng.address("table-name-suffix").slice(2, 12);
     const queryClient = createQueryClient();
 
+    const txTablesMutex = new Mutex();
+
     const tableName = `txs_test_${suffix}`;
     const txTable = await TxTable.create(queryClient, tableName);
 
@@ -178,6 +181,7 @@ export default class Fixture {
 
     return new TxService(
       queryClient,
+      txTablesMutex,
       txTable,
       futureTxTable,
       this.walletService,

--- a/test/helpers/Fixture.ts
+++ b/test/helpers/Fixture.ts
@@ -176,7 +176,13 @@ export default class Fixture {
       await queryClient.disconnect();
     });
 
-    return new TxService(txTable, futureTxTable, this.walletService, config);
+    return new TxService(
+      queryClient,
+      txTable,
+      futureTxTable,
+      this.walletService,
+      config,
+    );
   }
 
   async allTxs(


### PR DESCRIPTION
# Note: Depends on https://github.com/jzaki/aggregator/pull/32

The previous PR and this one are both changing `TxService`. This change builds upon that work (tx replacement) to avoid conflicts. Until that PR is merged github will display the combined diff here.

For the crux of these changes, take a look at:
- `Mutex.ts`
- `runQueryGroup.ts`
- Use of `runQueryGroup` in `TxService.ts`